### PR TITLE
Various XAudio2 fixes in particular for Windows 7

### DIFF
--- a/shared/BPCSharedComponent/DSound.cs
+++ b/shared/BPCSharedComponent/DSound.cs
@@ -344,7 +344,7 @@ namespace BPCSharedComponent.ExtendedAudio
 			// Don't forget there are two times more cells in the matrix if the source sound is stereo)
 			float[] outputMatrix = new float[srcChannelCount * dstChannelCount];
 			Array.Clear(outputMatrix, 0, outputMatrix.Length);
-			// From there, we'll hope that the sound file is either mono or stereo. If the WAV had more than 2 channels, it would be toO difficult to handle. 
+			// From there, we'll hope that the sound file is either mono or stereo. If the WAV had more than 2 channels, it would be too difficult to handle. 
 			// Similarly, we'll also only output to the front-left and front-right speakers for simplicity, e.g. like the XNA framework does. 
 			if (srcChannelCount == 1) // Mono source
 			{

--- a/shared/BPCSharedComponent/DSound.cs
+++ b/shared/BPCSharedComponent/DSound.cs
@@ -344,7 +344,7 @@ namespace BPCSharedComponent.ExtendedAudio
 			// Don't forget there are two times more cells in the matrix if the source sound is stereo)
 			float[] outputMatrix = new float[srcChannelCount * dstChannelCount];
 			Array.Clear(outputMatrix, 0, outputMatrix.Length);
-			// From there, we'll hope that the sound file is either mono or stereo. If the WAV had more than 2 channels, it would be to difficult to handle. 
+			// From there, we'll hope that the sound file is either mono or stereo. If the WAV had more than 2 channels, it would be toO difficult to handle. 
 			// Similarly, we'll also only output to the front-left and front-right speakers for simplicity, e.g. like the XNA framework does. 
 			if (srcChannelCount == 1) // Mono source
 			{

--- a/shared/BPCSharedComponent/DSound.cs
+++ b/shared/BPCSharedComponent/DSound.cs
@@ -61,7 +61,15 @@ namespace BPCSharedComponent.ExtendedAudio
 			NumPath = NSoundPath + "\\ns";
 			mainSoundDevice = new XAudio2();
 			mainMasteringVoice = new MasteringVoice(mainSoundDevice);
-			x3DAudio = new X3DAudio((Speakers)mainMasteringVoice.ChannelMask);
+			if (mainSoundDevice.Version == XAudio2Version.Version27)
+			{
+				WaveFormatExtensible deviceFormat = mainSoundDevice.GetDeviceDetails(0).OutputFormat;
+				x3DAudio = new X3DAudio(deviceFormat.ChannelMask);
+			}
+			else
+			{
+				x3DAudio = new X3DAudio((Speakers)mainMasteringVoice.ChannelMask);
+			}
 			musicDevice = new XAudio2();
 			musicMasteringVoice = new MasteringVoice(musicDevice);
 			alwaysLoudDevice = new XAudio2();
@@ -319,7 +327,14 @@ namespace BPCSharedComponent.ExtendedAudio
 		/// <param name="pan">The value by which to pan the sound. -1.0f is completely left, and 1.0f is completely right. 0.0f is center.</param>
 		public static void setPan(ExtendedAudioBuffer sound, float pan)
 		{
-			SpeakerConfiguration mask = (SpeakerConfiguration)mainMasteringVoice.ChannelMask;
+			SpeakerConfiguration mask;
+			if (mainSoundDevice.Version == XAudio2Version.Version27)
+			{
+				WaveFormatExtensible deviceFormat = mainSoundDevice.GetDeviceDetails(0).OutputFormat;
+				mask = (SpeakerConfiguration)deviceFormat.ChannelMask;
+			}
+			else
+				mask = (SpeakerConfiguration)mainMasteringVoice.ChannelMask;
 			float[] outputMatrix = new float[8];
 			float left = 0.5f - pan / 2;
 			float right = 0.5f + pan / 2;


### PR DESCRIPTION
This PR provides two fixes:
* Fixed speaker enumeration code when XAudio 2.8 is not available. This problem affected Windows 7, for which all 3D sounds were in the left speakers.
* Rewritten the DSound.setPan method which was only working with mono sounds as input: e.g. the missile launching sound was properly panned while the wind sound was not.